### PR TITLE
Bumping up repos-formula version

### DIFF
--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -9,7 +9,7 @@ git@github.com:ministryofjustice/nginx-formula.git==v2.1.0
 # Pin dep
 git@github.com:ministryofjustice/supervisor-formula.git==v1.0.0
 git@github.com:ministryofjustice/python-formula.git==v1.0.2
-git@github.com:ministryofjustice/repos-formula.git==v1.0.1
+git@github.com:ministryofjustice/repos-formula.git==v1.1.1
 git@github.com:ministryofjustice/apparmor-formula.git==v1.0.1
 
 git@github.com:ministryofjustice/redis-formula.git==v1.1.0-rc.lpa.2


### PR DESCRIPTION
This is to avoid nginx install failures. A new option has been added to dsd source repo stanza which applies for ALL archs.
